### PR TITLE
Change logolink to guide homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   <div class="page-wrap">
     <div class="side-bar">
       <!-- <a href="{{ site.url }}{{ site.baseurl }}" class="site-title fs-6 lh-tight">{{ site.title }}</a> -->
-      <a href="https://www.veeam.com/" target="_blank">
+      <a href="{{ site.url }}{{ site.baseurl }}">
         <img class="veeam_logo_lp" src="https://psr.veeam.com/global/img/logo/veeam_logo_lp_white.svg" alt="Veeam"/>
     </a>
       <!-- <span class="fs-3"><button class="js-main-nav-trigger navigation-list-toggle btn btn-outline" type="button" data-text-toggle="Hide">Menu</button></span> -->


### PR DESCRIPTION
Logo links to veeam.com for now, but I'd prefer to use it as a shortcut to the home page of the specific guide instead.
That's how most logos on websites work - they just bring you back to the overview.